### PR TITLE
IPv6 support, tests

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -120,17 +120,17 @@ func parseICMPEcho(b []byte) (*icmpEcho, error) {
 	return p, nil
 }
 
-func Ping(address string, timeout int) bool {
+func Ping(address string, timeout time.Duration) bool {
 	err := Pinger(address, timeout)
 	return err == nil
 }
 
-func Pinger(address string, timeout int) error {
+func Pinger(address string, timeout time.Duration) error {
 	c, err := net.Dial("ip4:icmp", address)
 	if err != nil {
 		return err
 	}
-	c.SetDeadline(time.Now().Add(time.Duration(timeout) * time.Second))
+	c.SetDeadline(time.Now().Add(timeout))
 	defer c.Close()
 
 	typ := icmpv4EchoRequest

--- a/ping_test.go
+++ b/ping_test.go
@@ -1,0 +1,61 @@
+package ping
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestPingIPv4(t *testing.T) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, addr := range addrs {
+			if addr.(*net.IPNet).IP.To4() == nil { // ipv6, skip
+				continue
+			}
+
+			t.Logf("pinging %q on interface %q", addr.(*net.IPNet).IP.String(), iface.Name)
+
+			// these are all local interfaces; should not fail.
+			if err := Pinger(&net.IPAddr{IP: addr.(*net.IPNet).IP, Zone: iface.Name}, 150*time.Millisecond); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+func TestPingIPv6(t *testing.T) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, addr := range addrs {
+			if addr.(*net.IPNet).IP.To4() != nil { // ipv4, skip
+				continue
+			}
+
+			t.Logf("pinging %q on interface %q", addr.(*net.IPNet).IP.String(), iface.Name)
+
+			// these are all local interfaces; should not fail.
+			if err := Pinger(&net.IPAddr{IP: addr.(*net.IPNet).IP, Zone: iface.Name}, 150*time.Millisecond); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This adds IPv6 support and tests against local IPs to the machine. Tests need to run as root. Types for Ping and Pinger were changed to better support fine-grained ping timeout and IPv6 addresses with zones.

Let me know if there are any questions.

/cc @shykes @lk4d4 @icecrime @tiborvass
